### PR TITLE
[Feat] #157 - 탭바 커스텀

### DIFF
--- a/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
+++ b/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
@@ -14,6 +14,9 @@ class TabBarController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setTabBar()
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        setTabBarHeight()
     }
 }
 

--- a/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
+++ b/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
@@ -14,6 +14,9 @@ class TabBarController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setTabBar()
+        setTabBarShadow()
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         setTabBarHeight()

--- a/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
+++ b/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
@@ -56,6 +56,12 @@ extension TabBarController {
         tabBar.backgroundColor = .white
         tabBar.tintColor = .primary
     }
+    private func setTabBarShadow() {
+        UITabBar.clearShadow()
+        tabBar.layer.applyShadow(color: .black, alpha: 0.15, x: 0, y: 3, blur: 14)
+    }
+}
+
 // MARK: - SetShadow
 
 extension CALayer {

--- a/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
+++ b/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
@@ -56,6 +56,23 @@ extension TabBarController {
         tabBar.backgroundColor = .white
         tabBar.tintColor = .primary
     }
+// MARK: - SetShadow
+
+extension CALayer {
+    func applyShadow(
+        color: UIColor = .black,
+        alpha: Float = 0.5,
+        x: CGFloat = 0,
+        y: CGFloat = 2,
+        blur: CGFloat = 4
+    ) {
+        shadowColor = color.cgColor
+        shadowOpacity = alpha
+        shadowOffset = CGSize(width: x, height: y)
+        shadowRadius = blur / 2.0
+    }
+}
+
 extension UITabBar {
     static func clearShadow() {
         UITabBar.appearance().shadowImage = UIImage()

--- a/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
+++ b/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
@@ -9,7 +9,9 @@ import UIKit
 
 class TabBarController: UITabBarController {
 
-    // MARK: Life Cycle
+private lazy var defaultTabBarHeight = { tabBar.frame.size.height }()
+    
+    // MARK: - Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
+++ b/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
@@ -37,17 +37,17 @@ extension TabBarController {
                                    title: "",
                                  tabBarImg: Constant.Image.tabBarMyDiary,
                                    tabBarSelectedImg: Constant.Image.tabBarMyDiarySelected,
-                                   renderingMode: .alwaysTemplate)
+                                   renderingMode: .alwaysOriginal)
         let openDiary = makeTabBar(viewController: OpenDiaryViewController(),
                                        title: "",
                                        tabBarImg: Constant.Image.tabBarOpenDiary,
                                  tabBarSelectedImg: Constant.Image.tabBarOpenDiarySelected,
-                                 renderingMode: .alwaysTemplate)
+                                 renderingMode: .alwaysOriginal)
         let scrapStash = makeTabBar(viewController: ScrapStashViewController(),
                                      title: "",
                                      tabBarImg: Constant.Image.tabBarStash,
                                  tabBarSelectedImg: Constant.Image.tabBarStashSelected,
-                                 renderingMode: .alwaysTemplate)
+                                 renderingMode: .alwaysOriginal)
         
         let tabs = [myDiary, openDiary, scrapStash]
     

--- a/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
+++ b/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
@@ -56,4 +56,10 @@ extension TabBarController {
         tabBar.backgroundColor = .white
         tabBar.tintColor = .primary
     }
+extension UITabBar {
+    static func clearShadow() {
+        UITabBar.appearance().shadowImage = UIImage()
+        UITabBar.appearance().backgroundImage = UIImage()
+        UITabBar.appearance().backgroundColor = UIColor.white
+    }
 }

--- a/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
+++ b/Smeme-iOS/Smeme-iOS/Sources/Screen/TabBar/TabBarController.swift
@@ -56,6 +56,17 @@ extension TabBarController {
         tabBar.backgroundColor = .white
         tabBar.tintColor = .primary
     }
+    
+    private func setTabBarHeight() {
+        let newTabBarHeight = defaultTabBarHeight + convertByHeightRatio(34)
+
+        var newFrame = tabBar.frame
+        newFrame.size.height = newTabBarHeight
+        newFrame.origin.y = view.frame.size.height - newTabBarHeight
+
+        tabBar.frame = newFrame
+    }
+
     private func setTabBarShadow() {
         UITabBar.clearShadow()
         tabBar.layer.applyShadow(color: .black, alpha: 0.15, x: 0, y: 3, blur: 14)


### PR DESCRIPTION
##  작업한 내용
탭바 커스텀 했습니다.

##  PR Point

탭바 높이값이 기존 뷰 보다 34씩 더해졌습니다. 
convertByHeightRatio(34) 값으로 넣었고, 컬렉션 뷰 아래 인셋을 추가로 주어야할 듯 합니다.

탭바 그림자 구현은
기존 그림자를 리셋 - 새로운 그림자 함수 만들고 넣기 방식으로 구현했습니다.

## 스크린샷

|뷰|설명|
|------|---|
|     ![Simulator Screen Recording - iPhone 13 mini - 2023-01-13 at 06 16 20](https://user-images.githubusercontent.com/114599559/212182975-4ae4b3cd-4d1f-4288-a4c1-09f98fea36c2.gif) |   밑에 셀들 덮이는거 보이시나요? 이거 때문에 수정 해야할듯! |

## 관련 이슈

- Resolved: #157 
