### PR TITLE
[Feat] #172 - floating 버튼 클릭해서 나오는 뷰에서 배경 클릭 시 이전화면으로 돌아가기

### DIFF
--- a/Smeme-iOS/Smeme-iOS/Sources/Screen/MyDiary/MyDiaryFloatingButtonViewController.swift
+++ b/Smeme-iOS/Smeme-iOS/Sources/Screen/MyDiary/MyDiaryFloatingButtonViewController.swift
@@ -57,6 +57,10 @@ final class MyDiaryFloatingButtonViewController: UIViewController {
         view.backgroundColor = .clear
     }
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
     private func setLayout() {
         view.addSubviews([floatingDimView, floatingButton, koreanDiaryButton, foreignDiaryButton])
         


### PR DESCRIPTION
##  작업한 내용
floating 버튼 클릭해서 나오는 뷰에서 배경 클릭 시 이전화면으로 돌아가기

## 스크린샷

|뷰|설명|
|------|---|
| <img src="https://user-images.githubusercontent.com/76610340/212308254-87bb952a-3199-49c3-9375-1fcf4d3ae3a2.gif" width="250"> | 플로팅 버튼 클릭 시 이전화면으로 돌아감    |


## 관련 이슈

- Resolved: #172 
